### PR TITLE
Check player data for corruption

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/commands/CommandUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandUtils.java
@@ -296,6 +296,11 @@ public final class CommandUtils {
 
         for (OfflinePlayer offlinePlayer : mcMMO.p.getServer().getOfflinePlayers()) {
             String playerName = offlinePlayer.getName();
+            
+            if (playerName == null) { //Do null checking here to detect corrupted data before sending it throuogh .equals
+            	System.err.println("[McMMO] Bad player data file with UIID " + offlinePlayer.getUniqueId() );
+            	continue; //Don't let an error here interrupt the loop
+            }
 
             if (partialName.equalsIgnoreCase(playerName)) {
                 // Exact match


### PR DESCRIPTION
Fixed a null pointer exception that occurred with corrupted player data